### PR TITLE
Fix truncation of long menu item names in Telegram buttons

### DIFF
--- a/src/main/java/kz/aday/bot/util/KeyboardUtil.java
+++ b/src/main/java/kz/aday/bot/util/KeyboardUtil.java
@@ -95,11 +95,20 @@ public class KeyboardUtil {
     return markup;
   }
 
+  private static final int MAX_BUTTON_TEXT_LENGTH = 40;
+
   private static String getTextButton(Set<Item> selectedItems, Item item) {
-    return item.getCategory().getDisplayName()
+    String prefix = item.getCategory().getDisplayName()
         + ": "
-        + (selectedItems.contains(item) ? " ✅" : "")
-        + item.getName();
+        + (selectedItems.contains(item) ? "✅ " : "");
+    String name = item.getName();
+    if (prefix.length() + name.length() > MAX_BUTTON_TEXT_LENGTH) {
+      int available = MAX_BUTTON_TEXT_LENGTH - prefix.length() - 1;
+      if (available > 3) {
+        name = name.substring(0, available) + "…";
+      }
+    }
+    return prefix + name;
   }
 
   public static void addButton(List<UserButton> userButtons, InlineKeyboardMarkup markup) {


### PR DESCRIPTION
## Проблема

Telegram визуально обрезает текст кнопок, которые превышают ширину отображения. Например:

> 🍗 Второе: Курица в томатном сальса и...

Текст обрезается самим Telegram, и пользователь не видит полное название блюда.

## Решение

В `KeyboardUtil.getTextButton()` добавлена превентивная обрезка: если суммарная длина текста кнопки превышает 40 символов, название блюда обрезается с добавлением `…`. Это позволяет всегда сохранять видимым префикс с категорией и контролировать место обрезки.

**До:**
```
🍗 Второе: Курица в томатном сальса и...   ← обрезает Telegram
```

**После:**
```
🍗 Второе: Курица в томатном са…           ← обрезаем мы сами
```

## Изменения

- `KeyboardUtil.java`: добавлена константа `MAX_BUTTON_TEXT_LENGTH = 40` и логика обрезки в `getTextButton()`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pck8GDRsMVah7LGRji1jJT)_