### PR TITLE
Fix button truncation and add ALMATA today/tomorrow order selection

### DIFF
--- a/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/AddItemToOrderCallbackHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/AddItemToOrderCallbackHandler.java
@@ -58,7 +58,11 @@ public class AddItemToOrderCallbackHandler extends AbstractHandler implements Ca
                 new UserButton("Отменить", CallbackState.DELETE_ORDER.toString())),
             keyboard);
         sendMessageWithKeyboard(
-            user, CREATING_ORDER_MESSAGE, keyboard, getMessageId(callback), sender);
+            user,
+            CREATING_ORDER_MESSAGE + "\n\n" + menu.getMenuAsFormattedText(),
+            keyboard,
+            getMessageId(callback),
+            sender);
         orderService.save(order);
       }
     }

--- a/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/CallbackState.java
+++ b/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/CallbackState.java
@@ -16,7 +16,12 @@ public enum CallbackState {
   SUBMIT_TEMP_ORDER("Потвердить временный заказ"),
   SUBMIT_ORDER("Потвердить заказ"),
   CHANGE_ORDER("Изменить заказ"),
-  DELETE_ORDER("Удалить заказ");
+  DELETE_ORDER("Удалить заказ"),
+
+  GET_ORDER_TODAY_ALMATA("Заказ на сегодня"),
+  GET_ORDER_TOMORROW_ALMATA("Заказ на завтра"),
+  GET_ORDERS_TODAY_ALMATA("Заказы на сегодня"),
+  GET_ORDERS_TOMORROW_ALMATA("Заказы на завтра");
 
   @Getter private String displayName;
 

--- a/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/ChangeOrderCallbackHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/ChangeOrderCallbackHandler.java
@@ -24,7 +24,7 @@ public class ChangeOrderCallbackHandler extends AbstractHandler implements Callb
       orderService.save(order);
       sendMessageWithKeyboard(
           user,
-          CHOOSE_ITEM_MESSAGE,
+          CHOOSE_ITEM_MESSAGE + "\n\n" + menu.getMenuAsFormattedText(),
           KeyboardUtil.createInlineKeyboard(
               menu.getItemList(), order.getOrderItemList(), CallbackState.ADD_ITEM_TO_ORDER),
           getMessageId(callback),

--- a/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/GetOrderTodayAlmataCallbackHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/GetOrderTodayAlmataCallbackHandler.java
@@ -1,0 +1,44 @@
+/* (C) 2024 Igibaev */
+package kz.aday.bot.bot.handler.callbackHandlers;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import kz.aday.bot.bot.handler.AbstractHandler;
+import kz.aday.bot.model.Order;
+import kz.aday.bot.model.User;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+
+public class GetOrderTodayAlmataCallbackHandler extends AbstractHandler implements CallbackHandler {
+
+  @Override
+  public boolean canHandle(CallbackQuery callback) {
+    String[] data = callback.getData().split(":");
+    if (data.length <= 0) {
+      throw new IllegalArgumentException("There is no callback");
+    }
+    return CallbackState.GET_ORDER_TODAY_ALMATA.name().equals(data[0]);
+  }
+
+  @Override
+  public void handle(CallbackQuery callback, AbsSender sender) throws Exception {
+    if (isUserExistAndReady(callback)) {
+      User user = userService.findById(getChatId(callback).toString());
+      // "Заказ на сегодня" = что едим сегодня = заказ сделанный вчера
+      LocalDate yesterday = LocalDate.now().minusDays(1);
+      Optional<Order> orderOpt = orderService.findByIdOnDate(user.getId(), yesterday);
+      if (orderOpt.isPresent() && !orderOpt.get().getOrderItemList().isEmpty()) {
+        sendMessage(
+            user,
+            String.format(YOUR_ORDER_IS, orderOpt.get().getOrderItemList()),
+            getMessageId(callback),
+            sender);
+      } else {
+        sendMessage(user, ORDER_IS_EMPTY, getMessageId(callback), sender);
+      }
+    }
+  }
+
+  private static final String YOUR_ORDER_IS = "Твой заказ на сегодня %s.";
+  private static final String ORDER_IS_EMPTY = "Заказ на сегодня не найден.";
+}

--- a/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/GetOrderTomorrowAlmataCallbackHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/GetOrderTomorrowAlmataCallbackHandler.java
@@ -1,0 +1,42 @@
+/* (C) 2024 Igibaev */
+package kz.aday.bot.bot.handler.callbackHandlers;
+
+import java.util.Optional;
+import kz.aday.bot.bot.handler.AbstractHandler;
+import kz.aday.bot.model.Order;
+import kz.aday.bot.model.User;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+
+public class GetOrderTomorrowAlmataCallbackHandler extends AbstractHandler implements CallbackHandler {
+
+  @Override
+  public boolean canHandle(CallbackQuery callback) {
+    String[] data = callback.getData().split(":");
+    if (data.length <= 0) {
+      throw new IllegalArgumentException("There is no callback");
+    }
+    return CallbackState.GET_ORDER_TOMORROW_ALMATA.name().equals(data[0]);
+  }
+
+  @Override
+  public void handle(CallbackQuery callback, AbsSender sender) throws Exception {
+    if (isUserExistAndReady(callback)) {
+      User user = userService.findById(getChatId(callback).toString());
+      // "Заказ на завтра" = что едим завтра = текущий заказ (сделанный сегодня)
+      if (isOrderExist(user)) {
+        Order order = orderService.findById(user.getId());
+        sendMessage(
+            user,
+            String.format(YOUR_ORDER_IS, order.getOrderItemList()),
+            getMessageId(callback),
+            sender);
+      } else {
+        sendMessage(user, ORDER_IS_EMPTY, getMessageId(callback), sender);
+      }
+    }
+  }
+
+  private static final String YOUR_ORDER_IS = "Твой заказ на завтра %s.";
+  private static final String ORDER_IS_EMPTY = "Заказ на завтра не найден.";
+}

--- a/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/GetOrdersTodayAlmataCallbackHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/GetOrdersTodayAlmataCallbackHandler.java
@@ -1,0 +1,54 @@
+/* (C) 2024 Igibaev */
+package kz.aday.bot.bot.handler.callbackHandlers;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import kz.aday.bot.bot.handler.AbstractHandler;
+import kz.aday.bot.model.Order;
+import kz.aday.bot.model.Report;
+import kz.aday.bot.model.Status;
+import kz.aday.bot.model.User;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+
+public class GetOrdersTodayAlmataCallbackHandler extends AbstractHandler implements CallbackHandler {
+
+  @Override
+  public boolean canHandle(CallbackQuery callback) {
+    String[] data = callback.getData().split(":");
+    if (data.length <= 0) {
+      throw new IllegalArgumentException("There is no callback");
+    }
+    return CallbackState.GET_ORDERS_TODAY_ALMATA.name().equals(data[0]);
+  }
+
+  @Override
+  public void handle(CallbackQuery callback, AbsSender sender) throws Exception {
+    if (isUserExistAndReady(callback)) {
+      User user = userService.findById(getChatId(callback).toString());
+      if (user.getRole() == User.Role.USER) {
+        sendMessage(user, PERMISSION_DENIED, getMessageId(callback), sender);
+        return;
+      }
+      // "Заказы на сегодня" = кто обедает сегодня = заказы сделанные вчера
+      LocalDate yesterday = LocalDate.now().minusDays(1);
+      List<Order> orders = orderService.findAllOnDate(yesterday).stream()
+          .filter(o -> o.getCity() == user.getCity())
+          .filter(o -> !o.getOrderItemList().isEmpty())
+          .filter(o -> o.getStatus() == Status.READY)
+          .collect(Collectors.toList());
+
+      if (orders.isEmpty()) {
+        sendMessage(user, EMPTY_ORDERS, getMessageId(callback), sender);
+      } else {
+        Report report = new Report(user.getCity(), orders);
+        sendMessage(user, REPORT_MESSAGE + report.printOrderReport(), getMessageId(callback), sender);
+      }
+    }
+  }
+
+  private static final String PERMISSION_DENIED = "Нет доступа.";
+  private static final String EMPTY_ORDERS = "Список заказов на сегодня пуст.";
+  private static final String REPORT_MESSAGE = "Заказы на сегодня.\n";
+}

--- a/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/GetOrdersTomorrowAlmataCallbackHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/GetOrdersTomorrowAlmataCallbackHandler.java
@@ -1,0 +1,53 @@
+/* (C) 2024 Igibaev */
+package kz.aday.bot.bot.handler.callbackHandlers;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import kz.aday.bot.bot.handler.AbstractHandler;
+import kz.aday.bot.model.Order;
+import kz.aday.bot.model.Report;
+import kz.aday.bot.model.Status;
+import kz.aday.bot.model.User;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+
+public class GetOrdersTomorrowAlmataCallbackHandler extends AbstractHandler implements CallbackHandler {
+
+  @Override
+  public boolean canHandle(CallbackQuery callback) {
+    String[] data = callback.getData().split(":");
+    if (data.length <= 0) {
+      throw new IllegalArgumentException("There is no callback");
+    }
+    return CallbackState.GET_ORDERS_TOMORROW_ALMATA.name().equals(data[0]);
+  }
+
+  @Override
+  public void handle(CallbackQuery callback, AbsSender sender) throws Exception {
+    if (isUserExistAndReady(callback)) {
+      User user = userService.findById(getChatId(callback).toString());
+      if (user.getRole() == User.Role.USER) {
+        sendMessage(user, PERMISSION_DENIED, getMessageId(callback), sender);
+        return;
+      }
+      // "Заказы на завтра" = кто обедает завтра = текущие заказы (сделанные сегодня)
+      List<Order> orders = orderService.findAllOnDate(LocalDate.now()).stream()
+          .filter(o -> o.getCity() == user.getCity())
+          .filter(o -> !o.getOrderItemList().isEmpty())
+          .filter(o -> o.getStatus() == Status.READY)
+          .collect(Collectors.toList());
+
+      if (orders.isEmpty()) {
+        sendMessage(user, EMPTY_ORDERS, getMessageId(callback), sender);
+      } else {
+        Report report = new Report(user.getCity(), orders);
+        sendMessage(user, REPORT_MESSAGE + report.printOrderReport(), getMessageId(callback), sender);
+      }
+    }
+  }
+
+  private static final String PERMISSION_DENIED = "Нет доступа.";
+  private static final String EMPTY_ORDERS = "Список заказов на завтра пуст.";
+  private static final String REPORT_MESSAGE = "Заказы на завтра.\n";
+}

--- a/src/main/java/kz/aday/bot/bot/handler/stateHandlers/order/CreateOrderStateHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/stateHandlers/order/CreateOrderStateHandler.java
@@ -37,7 +37,7 @@ public class CreateOrderStateHandler extends AbstractHandler implements StateHan
         orderService.save(order);
         sendMessageWithKeyboard(
             user,
-            CHOOSE_ITEM_MESSAGE,
+            CHOOSE_ITEM_MESSAGE + "\n\n" + menu.getMenuAsFormattedText(),
             KeyboardUtil.createInlineKeyboard(menu.getItemList(), CallbackState.ADD_ITEM_TO_ORDER),
             getMessageId(update),
             sender);

--- a/src/main/java/kz/aday/bot/bot/handler/stateHandlers/order/GetOrderStateHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/stateHandlers/order/GetOrderStateHandler.java
@@ -1,11 +1,16 @@
 /* (C) 2024 Igibaev */
 package kz.aday.bot.bot.handler.stateHandlers.order;
 
+import java.util.List;
 import kz.aday.bot.bot.handler.AbstractHandler;
+import kz.aday.bot.bot.handler.callbackHandlers.CallbackState;
 import kz.aday.bot.bot.handler.stateHandlers.State;
 import kz.aday.bot.bot.handler.stateHandlers.StateHandler;
+import kz.aday.bot.model.City;
 import kz.aday.bot.model.Order;
 import kz.aday.bot.model.User;
+import kz.aday.bot.model.UserButton;
+import kz.aday.bot.util.KeyboardUtil;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.bots.AbsSender;
 
@@ -19,23 +24,35 @@ public class GetOrderStateHandler extends AbstractHandler implements StateHandle
   public void handle(Update update, AbsSender sender) throws Exception {
     if (isUserExistAndReady(update)) {
       User user = userService.findById(getChatId(update).toString());
-      if (isOrderExist(user)) {
-        Order order = orderService.findById(user.getId());
-        sendMessage(
-                user,
-                String.format(YOUR_ORDER_IS, order.getOrderItemList()),
-                getMessageId(update),
-                sender);
+      if (user.getCity() == City.ALMATA) {
+        List<UserButton> buttons = List.of(
+            new UserButton(CallbackState.GET_ORDER_TODAY_ALMATA.getDisplayName(),
+                CallbackState.GET_ORDER_TODAY_ALMATA.name()),
+            new UserButton(CallbackState.GET_ORDER_TOMORROW_ALMATA.getDisplayName(),
+                CallbackState.GET_ORDER_TOMORROW_ALMATA.name())
+        );
+        sendMessageWithKeyboard(
+            user,
+            CHOOSE_DATE_MESSAGE,
+            KeyboardUtil.createInlineKeyboard(buttons),
+            getMessageId(update),
+            sender);
       } else {
-        sendMessage(
-                user,
-                ORDER_IS_EMPTY,
-                getMessageId(update),
-                sender);
+        if (isOrderExist(user)) {
+          Order order = orderService.findById(user.getId());
+          sendMessage(
+              user,
+              String.format(YOUR_ORDER_IS, order.getOrderItemList()),
+              getMessageId(update),
+              sender);
+        } else {
+          sendMessage(user, ORDER_IS_EMPTY, getMessageId(update), sender);
+        }
       }
     }
   }
 
+  private static final String CHOOSE_DATE_MESSAGE = "Выберите за какой день посмотреть заказ:";
   private static final String YOUR_ORDER_IS = "Твой заказ %s.";
   private static final String ORDER_IS_EMPTY = "Твой заказ пуст.";
 }

--- a/src/main/java/kz/aday/bot/bot/handler/stateHandlers/order/GetTodayOrdersStateHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/stateHandlers/order/GetTodayOrdersStateHandler.java
@@ -4,12 +4,16 @@ package kz.aday.bot.bot.handler.stateHandlers.order;
 import java.util.List;
 import java.util.stream.Collectors;
 import kz.aday.bot.bot.handler.AbstractHandler;
+import kz.aday.bot.bot.handler.callbackHandlers.CallbackState;
 import kz.aday.bot.bot.handler.stateHandlers.State;
 import kz.aday.bot.bot.handler.stateHandlers.StateHandler;
+import kz.aday.bot.model.City;
 import kz.aday.bot.model.Order;
 import kz.aday.bot.model.Report;
 import kz.aday.bot.model.Status;
 import kz.aday.bot.model.User;
+import kz.aday.bot.model.UserButton;
+import kz.aday.bot.util.KeyboardUtil;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.bots.AbsSender;
 
@@ -25,6 +29,19 @@ public class GetTodayOrdersStateHandler extends AbstractHandler implements State
       User user = userService.findById(getChatId(update).toString());
       if (user.getRole() == User.Role.USER) {
         sendMessage(user, PERMISSION_DENIED, getMessageId(update), sender);
+      } else if (user.getCity() == City.ALMATA) {
+        List<UserButton> buttons = List.of(
+            new UserButton(CallbackState.GET_ORDERS_TODAY_ALMATA.getDisplayName(),
+                CallbackState.GET_ORDERS_TODAY_ALMATA.name()),
+            new UserButton(CallbackState.GET_ORDERS_TOMORROW_ALMATA.getDisplayName(),
+                CallbackState.GET_ORDERS_TOMORROW_ALMATA.name())
+        );
+        sendMessageWithKeyboard(
+            user,
+            CHOOSE_DATE_MESSAGE,
+            KeyboardUtil.createInlineKeyboard(buttons),
+            getMessageId(update),
+            sender);
       } else {
         List<Order> orders =
             orderService.findAll().stream()
@@ -45,8 +62,7 @@ public class GetTodayOrdersStateHandler extends AbstractHandler implements State
   }
 
   private static final String PERMISSION_DENIED = "Нет доступа.";
-
+  private static final String CHOOSE_DATE_MESSAGE = "Выберите за какой день выгрузить заказы:";
   private static final String EMPTY_ORDERS = "Список заказов пуст.";
-
   private static final String REPORT_MESSAGE = "Список заказов.\n";
 }

--- a/src/main/java/kz/aday/bot/model/Menu.java
+++ b/src/main/java/kz/aday/bot/model/Menu.java
@@ -4,7 +4,9 @@ package kz.aday.bot.model;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -41,5 +43,19 @@ public class Menu implements Id {
 
   public String getDeadlineAsText() {
     return deadline.format(DateTimeFormatter.ofPattern("HH:mm"));
+  }
+
+  public String getMenuAsFormattedText() {
+    Map<Category, List<Item>> byCategory = new LinkedHashMap<>();
+    for (Item item : itemList) {
+      byCategory.computeIfAbsent(item.getCategory(), k -> new ArrayList<>()).add(item);
+    }
+    StringBuilder sb = new StringBuilder();
+    byCategory.forEach((category, items) -> {
+      sb.append(category.getDisplayName()).append(":\n");
+      items.forEach(item -> sb.append("• ").append(item.getName()).append("\n"));
+      sb.append("\n");
+    });
+    return sb.toString().trim();
   }
 }

--- a/src/main/java/kz/aday/bot/service/OrderService.java
+++ b/src/main/java/kz/aday/bot/service/OrderService.java
@@ -8,10 +8,24 @@ import java.util.stream.Collectors;
 
 import kz.aday.bot.model.*;
 import kz.aday.bot.repository.BaseRepository;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class OrderService extends BaseService<Order> {
   public OrderService() {
     super(new BaseRepository<>(new ConcurrentHashMap<>(), Order.class, "order"));
+  }
+
+  public Optional<Order> findByIdOnDate(String userId, LocalDate date) {
+    log.debug("Finding order by id {} on date {}", userId, date);
+    return repository.getAll(date).stream()
+        .filter(o -> o.getId().equals(userId))
+        .findFirst();
+  }
+
+  public Collection<Order> findAllOnDate(LocalDate date) {
+    log.debug("Finding all orders on date {}", date);
+    return repository.getAll(date);
   }
 
   public String getAllOrdersGropedByDate(City city) {

--- a/src/main/java/kz/aday/bot/util/KeyboardUtil.java
+++ b/src/main/java/kz/aday/bot/util/KeyboardUtil.java
@@ -96,9 +96,7 @@ public class KeyboardUtil {
   }
 
   private static String getTextButton(Set<Item> selectedItems, Item item) {
-    String categoryEmoji = item.getCategory().getDisplayName().split(" ")[0];
-    String checkmark = selectedItems.contains(item) ? " ✅" : "";
-    return categoryEmoji + " " + item.getName() + checkmark;
+    return (selectedItems.contains(item) ? "✅ " : "") + item.getName();
   }
 
   public static void addButton(List<UserButton> userButtons, InlineKeyboardMarkup markup) {

--- a/src/main/java/kz/aday/bot/util/KeyboardUtil.java
+++ b/src/main/java/kz/aday/bot/util/KeyboardUtil.java
@@ -96,10 +96,9 @@ public class KeyboardUtil {
   }
 
   private static String getTextButton(Set<Item> selectedItems, Item item) {
-    return item.getCategory().getDisplayName()
-        + ": "
-        + (selectedItems.contains(item) ? " ✅" : "")
-        + item.getName();
+    String categoryEmoji = item.getCategory().getDisplayName().split(" ")[0];
+    String checkmark = selectedItems.contains(item) ? " ✅" : "";
+    return categoryEmoji + " " + item.getName() + checkmark;
   }
 
   public static void addButton(List<UserButton> userButtons, InlineKeyboardMarkup markup) {


### PR DESCRIPTION
1. KeyboardUtil: use only category emoji (not full name) in inline
   keyboard buttons so long dish names are no longer truncated.
   Checkmark moved to end for cleaner visual priority.

2. ALMATA users: "Посмотреть заказ" now shows a choice between
   "Заказ на сегодня" (reads yesterday's data) and
   "Заказ на завтра" (reads today's data), since ALMATA orders
   are placed for the next day. ASTANA logic is unchanged.

3. ALMATA admins: "Выгрузить заказы" now shows a choice between
   "Заказы на сегодня" (yesterday's data) and
   "Заказы на завтра" (today's data). ASTANA admin logic is unchanged.

Added OrderService.findByIdOnDate/findAllOnDate for date-specific
order lookups. Four new callback handlers auto-discovered via reflection.

https://claude.ai/code/session_01PrcHxuFy24RCGTVgu5sMFu