### PR TITLE
Fix typos in Russian text and city name

### DIFF
--- a/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/AddItemToOrderCallbackHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/AddItemToOrderCallbackHandler.java
@@ -54,7 +54,7 @@ public class AddItemToOrderCallbackHandler extends AbstractHandler implements Ca
                 menu.getItemList(), order.getOrderItemList(), CallbackState.ADD_ITEM_TO_ORDER);
         KeyboardUtil.addButton(
             List.of(
-                new UserButton("Потвердить", CallbackState.SUBMIT_ORDER.toString()),
+                new UserButton("Подтвердить", CallbackState.SUBMIT_ORDER.toString()),
                 new UserButton("Отменить", CallbackState.DELETE_ORDER.toString())),
             keyboard);
         sendMessageWithKeyboard(

--- a/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/CallbackState.java
+++ b/src/main/java/kz/aday/bot/bot/handler/callbackHandlers/CallbackState.java
@@ -13,8 +13,8 @@ public enum CallbackState {
   CHANGE_MENU("Изменить меню"),
   CLEAR_MENU("Очистить меню"),
 
-  SUBMIT_TEMP_ORDER("Потвердить временный заказ"),
-  SUBMIT_ORDER("Потвердить заказ"),
+  SUBMIT_TEMP_ORDER("Подтвердить временный заказ"),
+  SUBMIT_ORDER("Подтвердить заказ"),
   CHANGE_ORDER("Изменить заказ"),
   DELETE_ORDER("Удалить заказ"),
 

--- a/src/main/java/kz/aday/bot/bot/handler/commandHamndlers/StartCommandHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/commandHamndlers/StartCommandHandler.java
@@ -58,7 +58,7 @@ public class StartCommandHandler extends AbstractHandler implements CommandHandl
                     menu.getItemList(),
                     order,
                     List.of(
-                        new UserButton("Потвердить", CallbackState.SUBMIT_ORDER.toString()),
+                        new UserButton("Подтвердить", CallbackState.SUBMIT_ORDER.toString()),
                         new UserButton("Изменить заказ", CallbackState.CHANGE_ORDER.toString()),
                         new UserButton("Удалить", CallbackState.DELETE_ORDER.toString()),
                         new UserButton("Вернуться", CallbackState.CANCEL.toString()))),

--- a/src/main/java/kz/aday/bot/bot/handler/stateHandlers/State.java
+++ b/src/main/java/kz/aday/bot/bot/handler/stateHandlers/State.java
@@ -24,7 +24,7 @@ public enum State {
   CHANGE_ORDER("Изменить заказ", Type.ACTION),
   DELETE_ORDER("Удалить заказ", Type.ACTION),
   RANDOM_ORDER("Рандомный заказ", Type.ACTION),
-  SUBMIT_ORDER("Потвердить заказ", Type.ACTION),
+  SUBMIT_ORDER("Подтвердить заказ", Type.ACTION),
 
   GET_TODAY_ORDERS("Выгрузить заказы", Type.ACTION),
   PUBLISH_MENU("Опубликовать меню", Type.ACTION),

--- a/src/main/java/kz/aday/bot/bot/handler/stateHandlers/order/SubmitOrderStateHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/stateHandlers/order/SubmitOrderStateHandler.java
@@ -57,7 +57,7 @@ public class SubmitOrderStateHandler extends AbstractHandler implements StateHan
 
   private static final String RETURN_TO_MENU = "Окей. Вернитесь в меню тогда /return";
 
-  private static final String ORDER_WAS_SUBMITED = "Твой заказ %s. Потвержден.";
+  private static final String ORDER_WAS_SUBMITED = "Твой заказ %s. Подтвержден.";
 
   private static final String YOUR_ORDER_IS = "Твой заказ %s. Чтобы подтвердить отправьте 'Да'.";
 

--- a/src/main/java/kz/aday/bot/bot/handler/stateHandlers/order/SubmitOrderStateHandler.java
+++ b/src/main/java/kz/aday/bot/bot/handler/stateHandlers/order/SubmitOrderStateHandler.java
@@ -59,7 +59,7 @@ public class SubmitOrderStateHandler extends AbstractHandler implements StateHan
 
   private static final String ORDER_WAS_SUBMITED = "Твой заказ %s. Потвержден.";
 
-  private static final String YOUR_ORDER_IS = "Твой заказ %s. Чтобы потвердить отправьте 'Да'.";
+  private static final String YOUR_ORDER_IS = "Твой заказ %s. Чтобы подтвердить отправьте 'Да'.";
 
   private static final String MENU_DEADLINE_IS_PASSED = "Дедлайн меню уже прошел.";
 }

--- a/src/main/java/kz/aday/bot/model/City.java
+++ b/src/main/java/kz/aday/bot/model/City.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 public enum City {
   ASTANA("Астана"),
-  ALMATA("Алмата");
+  ALMATA("Алматы");
 
   private final String value;
 


### PR DESCRIPTION
## Summary
This PR corrects spelling errors in Russian text strings and fixes the transliteration of a city name in the application.

## Key Changes
- Fixed typo in order confirmation message: "потвердить" → "подтвердить" (correct Russian spelling of "confirm")
- Fixed city name transliteration: "Алмата" → "Алматы" (correct Kazakh city name Almaty)

## Details
These are minor but important corrections that improve the accuracy of user-facing messages and data integrity:
- The order confirmation prompt in `SubmitOrderStateHandler` now uses the correct Russian spelling
- The `City` enum now correctly represents Almaty with its proper transliteration

https://claude.ai/code/session_01P7xQecxLCLUNKZLxHy7v2F